### PR TITLE
ci: grant the emulator access to /dev/kvm on hosted runners

### DIFF
--- a/.github/workflows/android-e2e-main.yml
+++ b/.github/workflows/android-e2e-main.yml
@@ -116,6 +116,15 @@ jobs:
             ~/.android/adb*
           key: avd-${{ env.AVD_API_LEVEL }}-${{ env.AVD_TARGET }}-${{ env.AVD_ARCH }}-${{ env.AVD_PROFILE }}
 
+      # GitHub's Linux runners expose /dev/kvm only to root until a udev rule
+      # opens it; without this the emulator silently runs with -accel off
+      # (ProbeKVM: This user doesn't have permissions to use KVM) and boots in
+      # minutes instead of seconds.
+      - name: Enable KVM for the emulator
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Create emulator snapshot for cache
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@v2


### PR DESCRIPTION
Same defect as water-rs/waterkit#29: the hosted Linux runner exposes `/dev/kvm` to root only, so the emulator step ran with `-accel off` (`ProbeKVM: This user does not have permissions to use KVM`) and booted in minutes. Add the documented udev rule ahead of the emulator step.