### PR TITLE
feat(gpu): forward keyboard, IME and scroll input to GPU surfaces

### DIFF
--- a/runtime/src/main/cpp/waterui.h
+++ b/runtime/src/main/cpp/waterui.h
@@ -35,6 +35,36 @@ typedef struct WuiArray {
 
 
 /**
+ * `Modifiers::SHIFT` — a shift key is held.
+ */
+#define WUI_SURFACE_MODIFIER_SHIFT 512
+
+/**
+ * `Modifiers::CONTROL` — a control key is held.
+ */
+#define WUI_SURFACE_MODIFIER_CONTROL 8
+
+/**
+ * `Modifiers::ALT` — an alt/option key is held.
+ */
+#define WUI_SURFACE_MODIFIER_ALT 1
+
+/**
+ * `Modifiers::META` — a meta/command/Windows key is held.
+ */
+#define WUI_SURFACE_MODIFIER_META 64
+
+/**
+ * `Modifiers::CAPS_LOCK` — caps lock is latched on.
+ */
+#define WUI_SURFACE_MODIFIER_CAPS_LOCK 4
+
+/**
+ * `Modifiers::NUM_LOCK` — num lock is latched on.
+ */
+#define WUI_SURFACE_MODIFIER_NUM_LOCK 128
+
+/**
  * FFI representation of `StretchAxis` enum.
  *
  * Specifies which axis (or axes) a view stretches to fill available space.
@@ -1188,6 +1218,101 @@ typedef enum WuiWebViewEventType {
    */
   WuiWebViewEventType_StateChanged = 7,
 } WuiWebViewEventType;
+
+/**
+ * Which event a [`WuiSurfaceInputEvent`] carries.
+ *
+ * The tag decides which of the struct's payload fields are read; the rest are
+ * ignored (their strings are still freed).
+ */
+typedef enum WuiSurfaceInputEventKind {
+  /**
+   * Keyboard focus entered or left the surface. Reads `focused`.
+   */
+  WuiSurfaceInputEventKind_Focus,
+  /**
+   * The modifier chord changed on its own. Reads `modifiers`.
+   */
+  WuiSurfaceInputEventKind_Modifiers,
+  /**
+   * The pointer moved. Reads `x`, `y`.
+   */
+  WuiSurfaceInputEventKind_PointerMove,
+  /**
+   * A pointer button changed state. Reads `pressed`, `button`, `x`, `y`.
+   */
+  WuiSurfaceInputEventKind_PointerButton,
+  /**
+   * A scroll gesture. Reads `x`, `y`, `delta_x`, `delta_y`, `scroll_unit`,
+   * `finished`.
+   */
+  WuiSurfaceInputEventKind_Scroll,
+  /**
+   * A key changed state. Reads `pressed`, `key`, `code`, `modifiers`,
+   * `repeat`.
+   */
+  WuiSurfaceInputEventKind_Key,
+  /**
+   * Committed text to insert at the caret. Reads `text`.
+   */
+  WuiSurfaceInputEventKind_TextInput,
+  /**
+   * An input-method composition session began. Reads nothing.
+   */
+  WuiSurfaceInputEventKind_CompositionStart,
+  /**
+   * The pre-edit text changed. Reads `text`, `caret`.
+   */
+  WuiSurfaceInputEventKind_CompositionUpdate,
+  /**
+   * The composition session ended and its text is inserted. Reads `text`.
+   */
+  WuiSurfaceInputEventKind_CompositionCommit,
+  /**
+   * The composition session was abandoned. Reads nothing.
+   */
+  WuiSurfaceInputEventKind_CompositionCancel,
+} WuiSurfaceInputEventKind;
+
+/**
+ * A pointer button, in the W3C UI Events vocabulary.
+ */
+typedef enum WuiSurfacePointerButton {
+  /**
+   * The primary button — the left button on a right-handed mouse, a tap.
+   */
+  WuiSurfacePointerButton_Primary,
+  /**
+   * The secondary button — the right button on a right-handed mouse.
+   */
+  WuiSurfacePointerButton_Secondary,
+  /**
+   * The middle button, usually the wheel pressed down.
+   */
+  WuiSurfacePointerButton_Middle,
+  /**
+   * The "back" side button.
+   */
+  WuiSurfacePointerButton_Back,
+  /**
+   * The "forward" side button.
+   */
+  WuiSurfacePointerButton_Forward,
+} WuiSurfacePointerButton;
+
+/**
+ * What one unit of a scroll delta means.
+ */
+typedef enum WuiScrollUnit {
+  /**
+   * Deltas count lines of text — a discrete mouse wheel.
+   */
+  WuiScrollUnit_Line,
+  /**
+   * Deltas are logical pixels — a trackpad or a precise wheel.
+   */
+  WuiScrollUnit_Pixel,
+} WuiScrollUnit;
 
 /**
  * 2D affine transform stored as a row-major 2x3 matrix.
@@ -6729,6 +6854,79 @@ typedef struct WuiGpuSurfaceInput {
 } WuiGpuSurfaceInput;
 
 /**
+ * One input event on its way to a GPU view.
+ *
+ * See the [module docs](self) for the flat-tagged shape and the string
+ * ownership rules.
+ */
+typedef struct WuiSurfaceInputEvent {
+  /**
+   * Which event this is, and therefore which fields below are read.
+   */
+  enum WuiSurfaceInputEventKind kind;
+  /**
+   * `Focus`: whether the surface gained (`true`) or lost focus.
+   */
+  bool focused;
+  /**
+   * `Modifiers`, `Key`: the modifier chord, as `WUI_SURFACE_MODIFIER_*` bits.
+   */
+  uint32_t modifiers;
+  /**
+   * `PointerMove`, `PointerButton`, `Scroll`: logical surface-local x.
+   */
+  double x;
+  /**
+   * `PointerMove`, `PointerButton`, `Scroll`: logical surface-local y.
+   */
+  double y;
+  /**
+   * `PointerButton`, `Key`: `true` for a press, `false` for a release.
+   */
+  bool pressed;
+  /**
+   * `PointerButton`: which button changed state.
+   */
+  enum WuiSurfacePointerButton button;
+  /**
+   * `Scroll`: horizontal delta, positive when the content should move left.
+   */
+  double delta_x;
+  /**
+   * `Scroll`: vertical delta, positive when the content should move up.
+   */
+  double delta_y;
+  /**
+   * `Scroll`: what one unit of the deltas means.
+   */
+  enum WuiScrollUnit scroll_unit;
+  /**
+   * `Scroll`: `true` on the event that ends a continuous gesture.
+   */
+  bool finished;
+  /**
+   * `Key`: the W3C `KeyboardEvent.key` name — `"a"`, `"Enter"`, `"ArrowUp"`.
+   */
+  struct WuiStr key;
+  /**
+   * `Key`: the W3C `KeyboardEvent.code` name — `"KeyA"`, `"Enter"`.
+   */
+  struct WuiStr code;
+  /**
+   * `TextInput`, `CompositionUpdate`, `CompositionCommit`: the text.
+   */
+  struct WuiStr text;
+  /**
+   * `Key`: `true` when the platform generated this press by auto-repeat.
+   */
+  bool repeat;
+  /**
+   * `CompositionUpdate`: caret byte offset within `text`, or `-1` for none.
+   */
+  int64_t caret;
+} WuiSurfaceInputEvent;
+
+/**
  * FFI representation of output size.
  */
 typedef enum WuiOutputSize_Tag {
@@ -11197,6 +11395,75 @@ void waterui_gpu_surface_drop(struct WuiGpuSurfaceState *state);
  */
 void waterui_gpu_surface_set_input(struct WuiGpuSurfaceState *state,
                                    struct WuiGpuSurfaceInput input);
+
+/**
+ * Whether this GPU view handles its own keyboard, IME, pointer and scroll input.
+ *
+ * Hosts ask once per registration and install a key/IME responder only for the
+ * surfaces that answer `true`; a view that merely draws keeps every event with
+ * the surrounding `WaterUI` widgets.
+ *
+ * # Safety
+ *
+ * `state` must be a valid pointer returned by
+ * [`waterui_gpu_surface_create`](super::gpu_surface::waterui_gpu_surface_create).
+ */
+bool waterui_gpu_surface_wants_input_events(const struct WuiGpuSurfaceState *state);
+
+/**
+ * Delivers one input event to the GPU view.
+ *
+ * The event is translated to [`SurfaceInputEvent`] and handed to
+ * [`GpuView::input`](waterui_graphics::GpuView::input) before this returns.
+ * All three of the event's strings are consumed, whatever its kind.
+ *
+ * # Returns
+ *
+ * Whether the event reached the view. `false` means this surface does not take
+ * input, or its asynchronous renderer setup has not finished yet — in both
+ * cases the host should fall through to its own handling of the event.
+ *
+ * # Panics
+ *
+ * Panics when the event's `key`/`code` are not W3C UI Events names, when
+ * `modifiers` carries a bit outside `WUI_SURFACE_MODIFIER_*`, or when `caret`
+ * is neither `-1` nor a UTF-8 boundary of `text` — see
+ * [`WuiSurfaceInputEvent`]'s conversion.
+ *
+ * # Safety
+ *
+ * `state` must be a valid pointer returned by
+ * [`waterui_gpu_surface_create`](super::gpu_surface::waterui_gpu_surface_create),
+ * and every [`WuiStr`] in `event` must be an owning handle from the matching
+ * FFI constructor.
+ */
+bool waterui_gpu_surface_send_input_event(struct WuiGpuSurfaceState *state,
+                                          struct WuiSurfaceInputEvent event);
+
+/**
+ * The GPU view's text caret, in logical surface-local coordinates.
+ *
+ * Native text-input clients place the input-method candidate window with it:
+ * `NSTextInputClient.firstRect(forCharacterRange:)` on macOS,
+ * `InputConnection`/`updateCursorAnchorInfo` on Android.
+ *
+ * # Returns
+ *
+ * Whether a caret was written to `out`. `false` leaves `out` untouched and
+ * means the view has no caret to place the panel against.
+ *
+ * # Panics
+ *
+ * Panics when `out` is null, or when the view reports a caret whose
+ * coordinates the `f32` layout ABI cannot represent.
+ *
+ * # Safety
+ *
+ * `state` must be a valid pointer returned by
+ * [`waterui_gpu_surface_create`](super::gpu_surface::waterui_gpu_surface_create),
+ * and `out` must point to writable storage for one [`WuiRect`].
+ */
+bool waterui_gpu_surface_ime_caret(const struct WuiGpuSurfaceState *state, struct WuiRect *out);
 
 /**
  * # Safety

--- a/runtime/src/main/java/dev/waterui/android/components/GpuSurfaceComponent.kt
+++ b/runtime/src/main/java/dev/waterui/android/components/GpuSurfaceComponent.kt
@@ -3,12 +3,15 @@ package dev.waterui.android.components
 import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.PixelFormat
+import android.graphics.Rect
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import android.view.Choreographer
 import android.view.GestureDetector
+import android.view.InputDevice
+import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.ScaleGestureDetector
 import android.view.Surface
@@ -16,6 +19,10 @@ import android.view.SurfaceHolder
 import android.view.SurfaceView
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowInsets
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputConnection
+import android.view.inputmethod.InputMethodManager
 import androidx.annotation.Keep
 import dev.waterui.android.runtime.GpuSurfaceStruct
 import dev.waterui.android.runtime.NativeBindings
@@ -89,6 +96,14 @@ internal class GpuSurfaceView(
     private var panOffsetX = 0f
     private var panOffsetY = 0f
     private var doubleTap = false
+    /**
+     * The event sink for a GPU view that draws its own interactive content.
+     *
+     * Null for the common case — a view that only draws — so no focus is
+     * claimed, no keystroke is intercepted, and the surrounding WaterUI widgets
+     * keep every event.
+     */
+    private var inputSink: GpuSurfaceInputSink? = null
     private val redrawRequest = Runnable {
         if (statePtr != 0L && refreshRendererReadiness()) {
             frameScheduler.requestFrame()
@@ -176,8 +191,56 @@ internal class GpuSurfaceView(
         } else {
             setZOrderOnTop(true)
         }
+        if (NativeBindings.waterui_gpu_surface_wants_input_events(statePtr)) {
+            inputSink = GpuSurfaceInputSink(statePtr)
+            isFocusable = true
+            isFocusableInTouchMode = true
+        }
         holder.addCallback(this)
         disposeWith(::disposeNativeState)
+    }
+
+    override fun onCheckIsTextEditor(): Boolean = inputSink != null
+
+    override fun onCreateInputConnection(outAttrs: EditorInfo): InputConnection? {
+        val sink = inputSink ?: return null
+        describeSurfaceEditor(outAttrs)
+        return GpuSurfaceInputConnection(this, sink)
+    }
+
+    override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
+        val sink = inputSink ?: return super.onKeyDown(keyCode, event)
+        return sendSurfaceKey(sink, event, pressed = true) || super.onKeyDown(keyCode, event)
+    }
+
+    override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
+        val sink = inputSink ?: return super.onKeyUp(keyCode, event)
+        return sendSurfaceKey(sink, event, pressed = false) || super.onKeyUp(keyCode, event)
+    }
+
+    override fun onFocusChanged(gainFocus: Boolean, direction: Int, previouslyFocusedRect: Rect?) {
+        super.onFocusChanged(gainFocus, direction, previouslyFocusedRect)
+        inputSink?.send(kind = WuiSurfaceInputEventKind.Focus, focused = gainFocus)
+    }
+
+    override fun onGenericMotionEvent(event: MotionEvent): Boolean {
+        val sink = inputSink
+        if (sink == null || event.actionMasked != MotionEvent.ACTION_SCROLL) {
+            return super.onGenericMotionEvent(event)
+        }
+        val density = resources.displayMetrics.density
+        // A wheel notch is a whole line and complete on its own; a trackpad or a
+        // precise wheel reports a fraction of one, which the view scales itself.
+        val fromWheel = event.isFromSource(InputDevice.SOURCE_CLASS_POINTER)
+        return sink.send(
+            kind = WuiSurfaceInputEventKind.Scroll,
+            x = (event.x / density).toDouble(),
+            y = (event.y / density).toDouble(),
+            deltaX = event.getAxisValue(MotionEvent.AXIS_HSCROLL).toDouble(),
+            deltaY = event.getAxisValue(MotionEvent.AXIS_VSCROLL).toDouble(),
+            scrollUnit = WuiScrollUnit.Line,
+            finished = fromWheel
+        ) || super.onGenericMotionEvent(event)
     }
 
     override fun surfaceCreated(_holder: SurfaceHolder) {
@@ -340,6 +403,7 @@ internal class GpuSurfaceView(
             MotionEvent.ACTION_CANCEL -> releaseActiveInput()
         }
         gestureActive = hasHit || scaleDetector.isInProgress
+        forwardPointerEvent(event)
         pushInput()
         if (refreshRendererReadiness()) {
             frameScheduler.requestFrame()
@@ -434,6 +498,52 @@ internal class GpuSurfaceView(
         }
     }
 
+    /**
+     * Reports the touch as a pointer event to a GPU view that takes its own input.
+     *
+     * Positions are logical, surface-local points — the vocabulary's contract —
+     * while the pointer snapshot beside it stays in the physical pixels its own
+     * consumers already read.
+     */
+    private fun forwardPointerEvent(event: MotionEvent) {
+        val sink = inputSink ?: return
+        val density = resources.displayMetrics.density
+        val x = (event.x / density).toDouble()
+        val y = (event.y / density).toDouble()
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                requestFocus()
+                showSoftKeyboard()
+                sink.send(kind = WuiSurfaceInputEventKind.PointerMove, x = x, y = y)
+                sink.send(
+                    kind = WuiSurfaceInputEventKind.PointerButton,
+                    x = x,
+                    y = y,
+                    pressed = true
+                )
+            }
+            MotionEvent.ACTION_MOVE ->
+                sink.send(kind = WuiSurfaceInputEventKind.PointerMove, x = x, y = y)
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL ->
+                sink.send(
+                    kind = WuiSurfaceInputEventKind.PointerButton,
+                    x = x,
+                    y = y,
+                    pressed = false
+                )
+        }
+    }
+
+    /** Raises the software keyboard for a GPU view that composes its own text. */
+    private fun showSoftKeyboard() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            windowInsetsController?.show(WindowInsets.Type.ime())
+            return
+        }
+        val manager = context.getSystemService(InputMethodManager::class.java) ?: return
+        manager.showSoftInput(this, 0)
+    }
+
     private fun pushInput() {
         if (!surfaceAttached) {
             return
@@ -481,6 +591,8 @@ internal class GpuSurfaceView(
             NativeBindings.waterui_gpu_surface_detach(statePtr)
             surfaceAttached = false
         }
+        inputSink?.invalidate()
+        inputSink = null
         NativeBindings.waterui_gpu_surface_drop(statePtr)
         statePtr = 0L
         holder.removeCallback(this)

--- a/runtime/src/main/java/dev/waterui/android/components/GpuSurfaceInput.kt
+++ b/runtime/src/main/java/dev/waterui/android/components/GpuSurfaceInput.kt
@@ -1,0 +1,452 @@
+package dev.waterui.android.components
+
+import android.util.Log
+import android.view.KeyEvent
+import android.view.View
+import android.view.inputmethod.BaseInputConnection
+import android.view.inputmethod.CursorAnchorInfo
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
+import dev.waterui.android.runtime.NativeBindings
+
+/**
+ * Keyboard, IME and scroll input for GPU surfaces that ask for it.
+ *
+ * A `GpuSurface` whose renderer reports `wants_input_events` draws its own
+ * interactive content — a browser engine, a terminal, an editor — and needs the
+ * events themselves rather than the per-frame pointer snapshot
+ * `waterui_gpu_surface_set_input` carries. This file is the Android half of
+ * that: it translates `KeyEvent`s and `InputConnection` calls into the
+ * backend-neutral surface vocabulary. No Android keycode crosses the ABI — keys
+ * travel as their W3C `KeyboardEvent.key` / `.code` names.
+ */
+
+internal const val GPU_SURFACE_INPUT_LOG_TAG = "WaterUI.GpuSurfaceInput"
+
+/** The event tag; the ordinals are the native `WuiSurfaceInputEventKind`. */
+internal enum class WuiSurfaceInputEventKind {
+    Focus,
+    Modifiers,
+    PointerMove,
+    PointerButton,
+    Scroll,
+    Key,
+    TextInput,
+    CompositionStart,
+    CompositionUpdate,
+    CompositionCommit,
+    CompositionCancel
+}
+
+/** The ordinals are the native `WuiSurfacePointerButton`. */
+internal enum class WuiSurfacePointerButton {
+    Primary,
+    Secondary,
+    Middle,
+    Back,
+    Forward
+}
+
+/** The ordinals are the native `WuiScrollUnit`. */
+internal enum class WuiScrollUnit {
+    Line,
+    Pixel
+}
+
+internal const val WUI_SURFACE_MODIFIER_SHIFT = 0x200
+internal const val WUI_SURFACE_MODIFIER_CONTROL = 0x8
+internal const val WUI_SURFACE_MODIFIER_ALT = 0x1
+internal const val WUI_SURFACE_MODIFIER_META = 0x40
+internal const val WUI_SURFACE_MODIFIER_CAPS_LOCK = 0x4
+internal const val WUI_SURFACE_MODIFIER_NUM_LOCK = 0x80
+
+/** The W3C name for a key the model has no name for. */
+internal const val WUI_SURFACE_UNIDENTIFIED = "Unidentified"
+
+/** The absent-caret sentinel the carrier's `caret` field uses. */
+internal const val WUI_SURFACE_CARET_NONE = -1L
+
+/**
+ * Android keycodes to W3C `KeyboardEvent.code` names.
+ *
+ * The table is the whole reason no platform keycode crosses the ABI: a GPU view
+ * asks where a key *sits*, and every backend answers in the same vocabulary.
+ */
+private val w3cCodes: Map<Int, String> = buildMap {
+    for (offset in 0..25) {
+        put(KeyEvent.KEYCODE_A + offset, "Key" + ('A' + offset))
+    }
+    for (digit in 0..9) {
+        put(KeyEvent.KEYCODE_0 + digit, "Digit$digit")
+        put(KeyEvent.KEYCODE_NUMPAD_0 + digit, "Numpad$digit")
+    }
+    for (function in 1..12) {
+        put(KeyEvent.KEYCODE_F1 + function - 1, "F$function")
+    }
+    put(KeyEvent.KEYCODE_ENTER, "Enter")
+    put(KeyEvent.KEYCODE_TAB, "Tab")
+    put(KeyEvent.KEYCODE_SPACE, "Space")
+    put(KeyEvent.KEYCODE_DEL, "Backspace")
+    put(KeyEvent.KEYCODE_FORWARD_DEL, "Delete")
+    put(KeyEvent.KEYCODE_ESCAPE, "Escape")
+    put(KeyEvent.KEYCODE_DPAD_UP, "ArrowUp")
+    put(KeyEvent.KEYCODE_DPAD_DOWN, "ArrowDown")
+    put(KeyEvent.KEYCODE_DPAD_LEFT, "ArrowLeft")
+    put(KeyEvent.KEYCODE_DPAD_RIGHT, "ArrowRight")
+    put(KeyEvent.KEYCODE_MOVE_HOME, "Home")
+    put(KeyEvent.KEYCODE_MOVE_END, "End")
+    put(KeyEvent.KEYCODE_PAGE_UP, "PageUp")
+    put(KeyEvent.KEYCODE_PAGE_DOWN, "PageDown")
+    put(KeyEvent.KEYCODE_INSERT, "Insert")
+    put(KeyEvent.KEYCODE_SHIFT_LEFT, "ShiftLeft")
+    put(KeyEvent.KEYCODE_SHIFT_RIGHT, "ShiftRight")
+    put(KeyEvent.KEYCODE_CTRL_LEFT, "ControlLeft")
+    put(KeyEvent.KEYCODE_CTRL_RIGHT, "ControlRight")
+    put(KeyEvent.KEYCODE_ALT_LEFT, "AltLeft")
+    put(KeyEvent.KEYCODE_ALT_RIGHT, "AltRight")
+    put(KeyEvent.KEYCODE_META_LEFT, "OSLeft")
+    put(KeyEvent.KEYCODE_META_RIGHT, "OSRight")
+    put(KeyEvent.KEYCODE_CAPS_LOCK, "CapsLock")
+    put(KeyEvent.KEYCODE_NUM_LOCK, "NumLock")
+    put(KeyEvent.KEYCODE_SCROLL_LOCK, "ScrollLock")
+    put(KeyEvent.KEYCODE_GRAVE, "Backquote")
+    put(KeyEvent.KEYCODE_MINUS, "Minus")
+    put(KeyEvent.KEYCODE_EQUALS, "Equal")
+    put(KeyEvent.KEYCODE_LEFT_BRACKET, "BracketLeft")
+    put(KeyEvent.KEYCODE_RIGHT_BRACKET, "BracketRight")
+    put(KeyEvent.KEYCODE_BACKSLASH, "Backslash")
+    put(KeyEvent.KEYCODE_SEMICOLON, "Semicolon")
+    put(KeyEvent.KEYCODE_APOSTROPHE, "Quote")
+    put(KeyEvent.KEYCODE_SLASH, "Slash")
+    put(KeyEvent.KEYCODE_COMMA, "Comma")
+    put(KeyEvent.KEYCODE_PERIOD, "Period")
+    put(KeyEvent.KEYCODE_NUMPAD_DIVIDE, "NumpadDivide")
+    put(KeyEvent.KEYCODE_NUMPAD_MULTIPLY, "NumpadMultiply")
+    put(KeyEvent.KEYCODE_NUMPAD_SUBTRACT, "NumpadSubtract")
+    put(KeyEvent.KEYCODE_NUMPAD_ADD, "NumpadAdd")
+    put(KeyEvent.KEYCODE_NUMPAD_DOT, "NumpadDecimal")
+    put(KeyEvent.KEYCODE_NUMPAD_COMMA, "NumpadComma")
+    put(KeyEvent.KEYCODE_NUMPAD_ENTER, "NumpadEnter")
+    put(KeyEvent.KEYCODE_NUMPAD_EQUALS, "NumpadEqual")
+    put(KeyEvent.KEYCODE_MENU, "ContextMenu")
+    put(KeyEvent.KEYCODE_BACK, "BrowserBack")
+    put(KeyEvent.KEYCODE_FORWARD, "BrowserForward")
+    put(KeyEvent.KEYCODE_VOLUME_UP, "VolumeUp")
+    put(KeyEvent.KEYCODE_VOLUME_DOWN, "VolumeDown")
+    put(KeyEvent.KEYCODE_VOLUME_MUTE, "VolumeMute")
+}
+
+/** W3C `key` names for keys that produce no character of their own. */
+private val w3cNamedKeys: Map<String, String> = buildMap {
+    put("Enter", "Enter")
+    put("NumpadEnter", "Enter")
+    put("Tab", "Tab")
+    put("Backspace", "Backspace")
+    put("Delete", "Delete")
+    put("Escape", "Escape")
+    put("ArrowUp", "ArrowUp")
+    put("ArrowDown", "ArrowDown")
+    put("ArrowLeft", "ArrowLeft")
+    put("ArrowRight", "ArrowRight")
+    put("Home", "Home")
+    put("End", "End")
+    put("PageUp", "PageUp")
+    put("PageDown", "PageDown")
+    put("Insert", "Insert")
+    put("ShiftLeft", "Shift")
+    put("ShiftRight", "Shift")
+    put("ControlLeft", "Control")
+    put("ControlRight", "Control")
+    put("AltLeft", "Alt")
+    put("AltRight", "Alt")
+    put("OSLeft", "Meta")
+    put("OSRight", "Meta")
+    put("CapsLock", "CapsLock")
+    put("NumLock", "NumLock")
+    put("ScrollLock", "ScrollLock")
+    put("ContextMenu", "ContextMenu")
+    put("BrowserBack", "BrowserBack")
+    put("BrowserForward", "BrowserForward")
+    put("VolumeUp", "AudioVolumeUp")
+    put("VolumeDown", "AudioVolumeDown")
+    put("VolumeMute", "AudioVolumeMute")
+    for (function in 1..12) {
+        put("F$function", "F$function")
+    }
+}
+
+/** The W3C `KeyboardEvent.code` of the physical key this event came from. */
+internal fun surfaceCode(event: KeyEvent): String {
+    val code = w3cCodes[event.keyCode]
+    if (code == null) {
+        Log.d(GPU_SURFACE_INPUT_LOG_TAG, "no W3C code for Android keycode ${event.keyCode}")
+        return WUI_SURFACE_UNIDENTIFIED
+    }
+    return code
+}
+
+/**
+ * The W3C `KeyboardEvent.key` — the value the layout and modifiers produce.
+ *
+ * A key that types a character reports that character; every other key reports
+ * the name the W3C model gives it.
+ */
+internal fun surfaceKey(event: KeyEvent, code: String): String {
+    w3cNamedKeys[code]?.let { return it }
+    val unicode = event.unicodeChar
+    if (unicode != 0) {
+        return unicode.toChar().toString()
+    }
+    // A chord such as Ctrl+A reports no character; the `key` is still the one
+    // the physical key types on its own.
+    val unmodified = event.getUnicodeChar(0)
+    if (unmodified != 0) {
+        return unmodified.toChar().toString()
+    }
+    return WUI_SURFACE_UNIDENTIFIED
+}
+
+/** The modifier chord, as `WUI_SURFACE_MODIFIER_*` bits. */
+internal fun surfaceModifiers(event: KeyEvent): Int {
+    var bits = 0
+    if (event.isShiftPressed) bits = bits or WUI_SURFACE_MODIFIER_SHIFT
+    if (event.isCtrlPressed) bits = bits or WUI_SURFACE_MODIFIER_CONTROL
+    if (event.isAltPressed) bits = bits or WUI_SURFACE_MODIFIER_ALT
+    if (event.isMetaPressed) bits = bits or WUI_SURFACE_MODIFIER_META
+    if (event.isCapsLockOn) bits = bits or WUI_SURFACE_MODIFIER_CAPS_LOCK
+    if (event.isNumLockOn) bits = bits or WUI_SURFACE_MODIFIER_NUM_LOCK
+    return bits
+}
+
+/** The byte offset of a UTF-16 index into `text`, as the carrier counts carets. */
+internal fun surfaceCaret(text: String, utf16Offset: Int): Long =
+    text.substring(0, utf16Offset.coerceIn(0, text.length))
+        .toByteArray(Charsets.UTF_8)
+        .size
+        .toLong()
+
+/**
+ * The GPU surface state an input source forwards its events to.
+ *
+ * The sink owns nothing: `GpuSurfaceView` drops the native state and calls
+ * [invalidate] first, so an input connection the IME still holds afterwards
+ * forwards nothing rather than writing through a freed handle.
+ */
+internal class GpuSurfaceInputSink(private var statePtr: Long) {
+    fun invalidate() {
+        statePtr = 0L
+    }
+
+    val isValid: Boolean get() = statePtr != 0L
+
+    @Suppress("LongParameterList") // The signature is the flat native input carrier.
+    fun send(
+        kind: WuiSurfaceInputEventKind,
+        focused: Boolean = false,
+        modifiers: Int = 0,
+        x: Double = 0.0,
+        y: Double = 0.0,
+        pressed: Boolean = false,
+        button: WuiSurfacePointerButton = WuiSurfacePointerButton.Primary,
+        deltaX: Double = 0.0,
+        deltaY: Double = 0.0,
+        scrollUnit: WuiScrollUnit = WuiScrollUnit.Pixel,
+        finished: Boolean = false,
+        key: String = "",
+        code: String = "",
+        text: String = "",
+        isRepeat: Boolean = false,
+        caret: Long = WUI_SURFACE_CARET_NONE
+    ): Boolean {
+        if (statePtr == 0L) {
+            return false
+        }
+        return NativeBindings.waterui_gpu_surface_send_input_event(
+            statePtr = statePtr,
+            kind = kind.ordinal,
+            focused = focused,
+            modifiers = modifiers,
+            x = x,
+            y = y,
+            pressed = pressed,
+            button = button.ordinal,
+            deltaX = deltaX,
+            deltaY = deltaY,
+            scrollUnit = scrollUnit.ordinal,
+            finished = finished,
+            key = key,
+            code = code,
+            text = text,
+            isRepeat = isRepeat,
+            caret = caret
+        )
+    }
+
+    /** The view's caret as `left`, `top`, `width`, `height` in logical points. */
+    fun imeCaret(): FloatArray? =
+        if (statePtr == 0L) null else NativeBindings.waterui_gpu_surface_ime_caret(statePtr)
+}
+
+/**
+ * The IME's connection to a GPU view that composes its own text.
+ *
+ * The surface owns its document and the neutral vocabulary is one-way plus a
+ * caret rect, so this connection mirrors no text: what the IME edits is the
+ * pre-edit buffer, and everything else is expressed as the key events the view
+ * would have received from a hardware keyboard.
+ */
+internal class GpuSurfaceInputConnection(
+    private val host: View,
+    private val sink: GpuSurfaceInputSink
+) : BaseInputConnection(host, false) {
+    private var composing = ""
+
+    override fun commitText(text: CharSequence?, newCursorPosition: Int): Boolean {
+        val value = text?.toString() ?: ""
+        val wasComposing = composing.isNotEmpty()
+        composing = ""
+        sink.send(
+            kind = if (wasComposing) {
+                WuiSurfaceInputEventKind.CompositionCommit
+            } else {
+                WuiSurfaceInputEventKind.TextInput
+            },
+            text = value
+        )
+        return true
+    }
+
+    override fun setComposingText(text: CharSequence?, newCursorPosition: Int): Boolean {
+        val value = text?.toString() ?: ""
+        val wasComposing = composing.isNotEmpty()
+        if (value.isEmpty()) {
+            composing = ""
+            if (wasComposing) {
+                sink.send(WuiSurfaceInputEventKind.CompositionCancel)
+            }
+            return true
+        }
+        if (!wasComposing) {
+            sink.send(WuiSurfaceInputEventKind.CompositionStart)
+        }
+        composing = value
+        // `newCursorPosition` is relative to the composing text: positive puts
+        // the caret after it, anything else puts it before.
+        val utf16Offset = if (newCursorPosition > 0) value.length else 0
+        sink.send(
+            kind = WuiSurfaceInputEventKind.CompositionUpdate,
+            text = value,
+            caret = surfaceCaret(value, utf16Offset)
+        )
+        return true
+    }
+
+    override fun finishComposingText(): Boolean {
+        if (composing.isEmpty()) {
+            return true
+        }
+        val value = composing
+        composing = ""
+        sink.send(kind = WuiSurfaceInputEventKind.CompositionCommit, text = value)
+        return true
+    }
+
+    override fun setComposingRegion(start: Int, end: Int): Boolean {
+        // Composing over already-committed text needs a document the host does
+        // not have; the IME falls back to `setComposingText` when this is
+        // refused, which the surface can honour.
+        return false
+    }
+
+    override fun deleteSurroundingText(beforeLength: Int, afterLength: Int): Boolean {
+        // The host holds no document to delete from, so the edit is expressed as
+        // the key presses that produce it — the same ones a hardware keyboard
+        // would have sent.
+        repeat(beforeLength) { sendSyntheticKey("Backspace") }
+        repeat(afterLength) { sendSyntheticKey("Delete") }
+        return true
+    }
+
+    override fun sendKeyEvent(event: KeyEvent?): Boolean {
+        val keyEvent = event ?: return false
+        return when (keyEvent.action) {
+            KeyEvent.ACTION_DOWN -> sendSurfaceKey(sink, keyEvent, pressed = true)
+            KeyEvent.ACTION_UP -> sendSurfaceKey(sink, keyEvent, pressed = false)
+            else -> false
+        }
+    }
+
+    override fun requestCursorUpdates(cursorUpdateMode: Int): Boolean {
+        val caret = sink.imeCaret() ?: return false
+        val manager = host.context.getSystemService(InputMethodManager::class.java) ?: return false
+        val density = host.resources.displayMetrics.density
+        val location = IntArray(2)
+        host.getLocationOnScreen(location)
+        val left = location[0] + caret[0] * density
+        val top = location[1] + caret[1] * density
+        val bottom = top + caret[3] * density
+        manager.updateCursorAnchorInfo(
+            host,
+            CursorAnchorInfo.Builder()
+                .setInsertionMarkerLocation(
+                    left,
+                    top,
+                    bottom,
+                    bottom,
+                    CursorAnchorInfo.FLAG_HAS_VISIBLE_REGION
+                )
+                .build()
+        )
+        return true
+    }
+
+    private fun sendSyntheticKey(name: String) {
+        for (pressed in listOf(true, false)) {
+            sink.send(
+                kind = WuiSurfaceInputEventKind.Key,
+                pressed = pressed,
+                key = name,
+                code = name
+            )
+        }
+    }
+}
+
+/** Forwards one Android key event as the neutral key event it stands for. */
+internal fun sendSurfaceKey(
+    sink: GpuSurfaceInputSink,
+    event: KeyEvent,
+    pressed: Boolean
+): Boolean {
+    val code = surfaceCode(event)
+    val modifiers = surfaceModifiers(event)
+    sink.send(kind = WuiSurfaceInputEventKind.Modifiers, modifiers = modifiers)
+    val consumed = sink.send(
+        kind = WuiSurfaceInputEventKind.Key,
+        modifiers = modifiers,
+        pressed = pressed,
+        key = surfaceKey(event, code),
+        code = code,
+        isRepeat = pressed && event.repeatCount > 0
+    )
+    // A key that types a character is followed by the text it produced, exactly
+    // as the web platform does.
+    if (pressed && consumed) {
+        val unicode = event.unicodeChar
+        if (unicode != 0 && !Character.isISOControl(unicode)) {
+            sink.send(
+                kind = WuiSurfaceInputEventKind.TextInput,
+                text = unicode.toChar().toString()
+            )
+        }
+    }
+    return consumed
+}
+
+/** Describes the surface to the IME as a plain text field it may compose into. */
+internal fun describeSurfaceEditor(outAttrs: EditorInfo) {
+    outAttrs.inputType = EditorInfo.TYPE_CLASS_TEXT
+    outAttrs.imeOptions = EditorInfo.IME_ACTION_NONE or EditorInfo.IME_FLAG_NO_FULLSCREEN
+    outAttrs.initialSelStart = 0
+    outAttrs.initialSelEnd = 0
+}

--- a/runtime/src/main/java/dev/waterui/android/ffi/WatcherJni.kt
+++ b/runtime/src/main/java/dev/waterui/android/ffi/WatcherJni.kt
@@ -503,5 +503,27 @@ object WatcherJni {
         height: Int,
         scale: Float
     ): Boolean
+    @JvmStatic external fun gpuSurfaceWantsInputEvents(statePtr: Long): Boolean
+    @Suppress("LongParameterList") // Signature mirrors the flat native surface-input carrier.
+    @JvmStatic external fun gpuSurfaceSendInputEvent(
+        statePtr: Long,
+        kind: Int,
+        focused: Boolean,
+        modifiers: Int,
+        x: Double,
+        y: Double,
+        pressed: Boolean,
+        button: Int,
+        deltaX: Double,
+        deltaY: Double,
+        scrollUnit: Int,
+        finished: Boolean,
+        key: String,
+        code: String,
+        text: String,
+        isRepeat: Boolean,
+        caret: Long
+    ): Boolean
+    @JvmStatic external fun gpuSurfaceImeCaret(statePtr: Long): FloatArray?
     @JvmStatic external fun gpuSurfaceDrop(statePtr: Long)
 }

--- a/runtime/src/main/java/dev/waterui/android/runtime/NativeBindings.kt
+++ b/runtime/src/main/java/dev/waterui/android/runtime/NativeBindings.kt
@@ -463,6 +463,48 @@ internal object NativeBindings {
         height: Int,
         scale: Float
     ): Boolean = WatcherJni.gpuSurfaceRender(statePtr, width, height, scale)
+    fun waterui_gpu_surface_wants_input_events(statePtr: Long): Boolean =
+        WatcherJni.gpuSurfaceWantsInputEvents(statePtr)
+    @Suppress("LongParameterList") // Direct JNI transfer avoids allocating an event envelope per keystroke.
+    fun waterui_gpu_surface_send_input_event(
+        statePtr: Long,
+        kind: Int,
+        focused: Boolean,
+        modifiers: Int,
+        x: Double,
+        y: Double,
+        pressed: Boolean,
+        button: Int,
+        deltaX: Double,
+        deltaY: Double,
+        scrollUnit: Int,
+        finished: Boolean,
+        key: String,
+        code: String,
+        text: String,
+        isRepeat: Boolean,
+        caret: Long
+    ): Boolean = WatcherJni.gpuSurfaceSendInputEvent(
+        statePtr,
+        kind,
+        focused,
+        modifiers,
+        x,
+        y,
+        pressed,
+        button,
+        deltaX,
+        deltaY,
+        scrollUnit,
+        finished,
+        key,
+        code,
+        text,
+        isRepeat,
+        caret
+    )
+    fun waterui_gpu_surface_ime_caret(statePtr: Long): FloatArray? =
+        WatcherJni.gpuSurfaceImeCaret(statePtr)
     fun waterui_gpu_surface_drop(statePtr: Long) = WatcherJni.gpuSurfaceDrop(statePtr)
 
     // ========== Reactive State Creation (for theme) ==========


### PR DESCRIPTION
The Android half of water-rs/waterui#197.

A `GpuSurface` whose renderer reports `wants_input_events` draws its own interactive content — a browser engine, a terminal, an editor — and needs the events themselves, not the per-frame pointer snapshot `waterui_gpu_surface_set_input` carries. The surface view had no way to give it those.

`GpuSurfaceInput.kt` is the missing half: key events, an `InputConnection` for composition, wheel scroll and pointer events, all translated into the backend-neutral surface vocabulary and sent through `waterui_gpu_surface_send_input_event`. `GpuSurfaceView` claims focus and raises the software keyboard **only** when the renderer asks for input, so a view that merely draws is unchanged.

No Android keycode crosses the ABI: keycodes map to W3C `KeyboardEvent.code` names and the character a key types to `KeyboardEvent.key`.

The surface owns its document, so the connection mirrors no text: it composes into the pre-edit buffer, refuses `setComposingRegion` (which needs a document the host does not have — the IME then falls back to `setComposingText`, which the surface can honour), expresses surrounding-text deletion as the key presses that produce it, and anchors the candidate window on `waterui_gpu_surface_ime_caret`.

Positions cross as logical, surface-local points, which is the vocabulary's contract; the pointer snapshot beside it keeps the physical pixels its own consumers already read.

`waterui.h` is regenerated from the superproject, not hand-edited.

### Verification

- `./gradlew runtime:assembleDebug --rerun-tasks` — BUILD SUCCESSFUL, no warnings
- `./gradlew :runtime:detekt :runtime:testDebugUnitTest --rerun-tasks` — BUILD SUCCESSFUL
- `./gradlew runtime:lintDebug` — fails with 19 errors, **all pre-existing and none in the files this PR touches** (`NewApi` on `Canvas#drawColor` in ColorPicker/ResolvedColor/ResolvedGradient/ResolvedShape, `GradleDependency` "a newer version is available", `UseKtx` in NavigationComponents/RustLayoutViewGroup, `ClickableViewAccessibility` in WaterUiRootView). `lint { warningsAsErrors = true }` turns the version-availability advisories into errors, so that gate rots on its own schedule.